### PR TITLE
adding really basic struct functionality

### DIFF
--- a/smop/backend.py
+++ b/smop/backend.py
@@ -394,7 +394,18 @@ def _backend(self,level=0):
 def _backend(self,level=0):
     return "%s.lower() == %s.lower()" % (self.args[0]._backend(),
                                        self.args[1]._backend())
-                       
+
+@extend(node.struct)
+@exceptions
+def _backend(self,level=0):
+    return "type('struct', (), {})()"
+
+@extend(node.isfield)
+@exceptions
+def _backend(self,level=0):
+    return "hasattr(%s, %s)" % (self.args[0]._backend(),
+                                self.args[1]._backend())
+
 @extend(node.isequal)
 @exceptions
 def _backend(self,level=0):

--- a/smop/node.py
+++ b/smop/node.py
@@ -319,6 +319,7 @@ builtins_list = [
     "isempty",
     "isequal",
     "isinf",
+    "isfield",
     "isnan",
     "length",
     "load",
@@ -340,6 +341,7 @@ builtins_list = [
     "sort",
     "strcmp",
     "strcmpi",
+    "struct",
     "sub", # synthetic opcode
     "sum",
     "transpose",


### PR DESCRIPTION
This takes care of simple cases like:

```
foo = struct();
foo.a = 4;
if isfield(foo, 'a'), disp("It works"); end
```

The `type('struct', (), {})()` code is a bit of a hack, to overcome the limitation on assigning new attributes to `object()`.
