### PR TITLE
convert Inf to np.inf

### DIFF
--- a/smop/backend.py
+++ b/smop/backend.py
@@ -500,3 +500,8 @@ def _backend(self,level=0):
 @exceptions
 def _backend(self,level=0):
     return "%s" % self
+
+@extend(node.Inf)
+@exceptions
+def _backend(self,level=0):
+    return "np.inf"

--- a/smop/node.py
+++ b/smop/node.py
@@ -316,6 +316,7 @@ builtins_list = [
     "fopen",
     "getfield",
     "inf", "inf0",
+    "Inf",
     "isempty",
     "isequal",
     "isinf",


### PR DESCRIPTION
Previously, `Inf` would pass through unaltered.

Note that this only applies to the `Inf` constant, and not the `inf` function.
