### PR TITLE
detect docstrings and treat them as such

### DIFF
--- a/smop/backend.py
+++ b/smop/backend.py
@@ -314,10 +314,19 @@ def _backend(self,level=0):
 @exceptions
 def _backend(self,level=0):
     if not self.use_nargin:
-        s = "def %s(%s):" %  (self.ident._backend(),
-                              self.args._backend())
+        s = "def %s(%s):" % (self.ident._backend(),
+                             self.args._backend())
     else:
         s = "def %s(*varargin):" % self.ident._backend()
+    if self.docstring:
+        s += '\n    """' + self.docstring[0].lstrip()
+        for d in self.docstring[1:]:
+            if d.strip():
+                s += '\n    ' + d
+            else:
+                s += '\n'
+        s += '\n    """'
+    if self.use_nargin:
         s += "\n    nargin = len(varargin)"
         for i in range(len(self.args)):
             s += "\n    if nargin > %d:" % i

--- a/smop/main.py
+++ b/smop/main.py
@@ -92,7 +92,7 @@ def main():
             # move each comment alone on a line
             # to avoid errors by trailing comment
             # and minimally change parsing rules
-            buf = re.sub("%", "\n %", buf)
+            buf = re.sub("%+", "\n %", buf)
             
             func_list = parse.parse(buf if buf[-1]=='\n' else buf+'\n',
                                     with_comments)

--- a/smop/node.py
+++ b/smop/node.py
@@ -152,7 +152,7 @@ class let(stmt,recordtype("let",
     def __str__(self):
         return "%s=%s" % (str(self.ret), str(self.args))
     
-class func_decl(stmt,recordtype("func_decl","ident ret args decl_list use_nargin",default=None)):
+class func_decl(stmt,recordtype("func_decl","ident ret args decl_list use_nargin docstring",default=None)):
     pass
 
 class lambda_expr(func_decl):

--- a/smop/resolve.py
+++ b/smop/resolve.py
@@ -194,7 +194,11 @@ def _resolve(self,symtab):
     self.head._resolve(symtab)
     self.body._resolve(symtab)
     self.head.ret._resolve(symtab)
-        
+    docstring = []
+    while type(self.body[0]) is node.comment:
+        docstring.append(str(self.body.pop(0))[1:])
+    self.head.docstring = docstring
+
 @extend(node.global_list)
 @extend(node.concat_list)
 @extend(node.expr_list)


### PR DESCRIPTION
This checks for the first unbroken line of comments
directly following a function declaration,
and hoists them into a docstring.

For example, with the input file `test.m`:

``` matlab
function y = test(x)
% This is a test function.
%
% Usage:
%   y = test(x);

y = x;  % magic
```

We get:

``` python
# Autogenerated with SMOP version 0.23
# smop/main.py test/test.m -o test/test.py
from __future__ import division
import numpy as np
from scipy.io import loadmat,savemat
import os

def test(x):
    """This is a test function.

     Usage:
       y = test(x);
    """
    y = x
    # magic
    return y
```
