### PR TITLE
call _backend for vararg names

### DIFF
--- a/smop/backend.py
+++ b/smop/backend.py
@@ -330,7 +330,7 @@ def _backend(self,level=0):
         s += "\n    nargin = len(varargin)"
         for i in range(len(self.args)):
             s += "\n    if nargin > %d:" % i
-            s += "\n        %s = varargin[%d]" % (self.args[i], i)
+            s += "\n        %s = varargin[%d]" % (self.args[i]._backend(), i)
     return s
 
 """


### PR DESCRIPTION
This ensures that vararg variable names will match the rest of the code.
For example, the reserved name `dir` will be rewritten to `dir_`.
