### PR TITLE
#79 If readline is not available, try pyreadline

### DIFF
--- a/smop/lexer.py
+++ b/smop/lexer.py
@@ -6,7 +6,10 @@ import re
 from zlib import adler32
 import lex
 from lex import TOKEN
-import readline
+try:
+  import readline
+except ImportError:
+  import pyreadline as readline
 
 class IllegalCharacterError(Exception):
     pass

--- a/smop/main.py
+++ b/smop/main.py
@@ -6,7 +6,10 @@ import sys,cPickle,glob,os
 import getopt,re
 import lexer,parse,resolve,backend,options,node,graphviz
 import networkx as nx
-import readline
+try:
+  import readline
+except ImportError:
+  import pyreadline as readline
 #from runtime import *
 #from version import __version__
 __version__ = version.__version__


### PR DESCRIPTION
If we get an "ImportError: No module named readline" on Windows, we try to import pyreadline as readline instead.