### PR TITLE
Fix name of output file in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Installation
    $ tar zxvf smop.tar.gz
    $ cd smop/smop
    $ python main.py solver.m
-   $ python go.py
+   $ python solver.py
 
 Working example
 ===============


### PR DESCRIPTION
The name of the output Python file is the same as the input Matlab file as per the the line https://github.com/victorlei/smop/blob/master/smop/main.py#L35.
