### PR TITLE
bug fix: arange (when step < 0)

### DIFF
--- a/smop/core.py
+++ b/smop/core.py
@@ -361,8 +361,9 @@ def arange(start,stop,step=1,**kwargs):
     >>> size(a)
     matlabarray([[ 1, 10]])
     """
+    expand_value = 1 if step > 0 else -1
     return matlabarray(np.arange(start,
-                                 stop+1,
+                                 stop+expand_value,
                                  step,
                                  **kwargs).reshape(1,-1),**kwargs)
 def cat(*args):


### PR DESCRIPTION
Previous arange function have bug when called like arange(10, 1, -1)