### PR TITLE
removed AttributeError and debug-printout

### DIFF
--- a/smop/resolve.py
+++ b/smop/resolve.py
@@ -50,8 +50,8 @@ def resolve(t, symtab=None, fp=None, func_name=None):
     do_resolve(t,symtab)
     G = as_networkx(t)
     for n in G.nodes():
-        print(n.__class__.__name__)
-        u = G.node[n]["ident"]
+        # print(n.__class__.__name__)
+        u = G.nodes[n]["ident"]
         if u.props:
             pass
         elif G.out_edges(n) and G.in_edges(n):
@@ -63,7 +63,7 @@ def resolve(t, symtab=None, fp=None, func_name=None):
             u.props = "R" # ref
         else:
             u.props = "F" # ???
-        G.node[n]["label"] = "%s\\n%s" % (n, u.props)
+        G.nodes[n]["label"] = "%s\\n%s" % (n, u.props)
     return G
 
 def do_resolve(t,symtab):


### PR DESCRIPTION
Removed random print(n.__class__.__name__) debug printout (shows "str" only anway) and made translation work by changing "G.node" to "G.nodes" on two occasions. Maybe networx or node implementations changed? Cured error: "AttributeError: 'DiGraph' object has no attribute 'node'"