### PR TITLE
fixed AttributeError 'node' to '_node'.

### DIFF
--- a/smop/resolve.py
+++ b/smop/resolve.py
@@ -51,7 +51,7 @@ def resolve(t, symtab=None, fp=None, func_name=None):
     G = as_networkx(t)
     for n in G.nodes():
         print(n.__class__.__name__)
-        u = G.node[n]["ident"]
+        u = G._node[n]["ident"]
         if u.props:
             pass
         elif G.out_edges(n) and G.in_edges(n):
@@ -63,7 +63,7 @@ def resolve(t, symtab=None, fp=None, func_name=None):
             u.props = "R" # ref
         else:
             u.props = "F" # ???
-        G.node[n]["label"] = "%s\\n%s" % (n, u.props)
+        G._node[n]["label"] = "%s\\n%s" % (n, u.props)
     return G
 
 def do_resolve(t,symtab):


### PR DESCRIPTION
Was getting this error when running smop3:

Traceback (most recent call last):
  File ".../smop/main.py", line 66, in main
    G = resolve.resolve(stmt_list)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../smop/resolve.py", line 66, in resolve
    G.node[n]["label"] = "%s\\n%s" % (n, u.props)
    ^^^^^^
AttributeError: 'DiGraph' object has no attribute 'node'. Did you mean: '_node'?
Errors: 1

Fixed by following the AttributError message for lines 54 and 66. Maybe node library changed.